### PR TITLE
chore: Fix Prevent $$ Escaping in Password Fields within Docker Compose

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -83,7 +83,7 @@ services:
             - "1433:1433"
         environment:
             ACCEPT_EULA: Y
-            MSSQL_SA_PASSWORD: S7$0nGpA$w0rD
+            MSSQL_SA_PASSWORD: "S7$0nGpAw0rD"
         volumes:
             - llana-mssql-data:/var/opt/mssql
             - ../demo/databases/mssql.sql:/docker-entrypoint-initdb.d/mssql.sql

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -83,7 +83,7 @@ services:
             - "1433:1433"
         environment:
             ACCEPT_EULA: Y
-            MSSQL_SA_PASSWORD: S7$0nGpA$$w0rD
+            MSSQL_SA_PASSWORD: yourStrong(!)Password
         volumes:
             - llana-mssql-data:/var/opt/mssql
             - ../demo/databases/mssql.sql:/docker-entrypoint-initdb.d/mssql.sql

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -83,7 +83,7 @@ services:
             - "1433:1433"
         environment:
             ACCEPT_EULA: Y
-            MSSQL_SA_PASSWORD: yourStrong(!)Password
+            MSSQL_SA_PASSWORD: S7$0nGpA$w0rD
         volumes:
             - llana-mssql-data:/var/opt/mssql
             - ../demo/databases/mssql.sql:/docker-entrypoint-initdb.d/mssql.sql


### PR DESCRIPTION
This PR addresses an issue where using consecutive $$ in Docker Compose password fields results in unintended escaping. Docker Compose interprets $$ as a literal $, causing problems when passwords contain consecutive dollar signs.