### PR TITLE
Allow auth cookies to have no domain

### DIFF
--- a/src/app.controller.auth.ts
+++ b/src/app.controller.auth.ts
@@ -191,19 +191,12 @@ function getAuthCookieOpts(isRefreshToken: boolean): CookieOptions {
 		throw new Error('AUTH_COOKIES_DOMAIN or BASE_URL_API must be set in production')
 	}
 
-	let domain
-	try {
-		domain = process.env.AUTH_COOKIES_DOMAIN || new URL(process.env.BASE_URL_API).hostname
-	} catch {
-		throw new Error('Could not parse AUTH_COOKIES_DOMAIN or BASE_URL_API. Make sure they are valid URLs.')
-	}
-
 	const opts: Record<string, any> = {
 		httpOnly: true,
 		secure: true,
 		sameSite: 'none',
 		maxAge: convertJwtExpiryToMs(isRefreshToken ? process.env.JWT_REFRESH_EXPIRES_IN : process.env.JWT_EXPIRES_IN),
-		...(domain ? { domain } : {}),
+		...(process.env.AUTH_COOKIES_DOMAIN ? { domain: process.env.AUTH_COOKIES_DOMAIN } : {}),
 		path: '/',
 	}
 	return opts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified cookie domain handling by only using the configured cookie domain if set, without attempting to parse a fallback from the API base URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->