### PR TITLE
override multer to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,9 @@
 				"tsconfig-paths": "^4.2.0",
 				"typescript": "^5.8.3",
 				"webpack": "^5.99.9"
+			},
+			"engines": {
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -6795,9 +6798,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.155",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-			"integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+			"version": "1.5.157",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
+			"integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -8946,9 +8949,9 @@
 			}
 		},
 		"node_modules/jackspeak": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-			"integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
@@ -10389,10 +10392,9 @@
 			}
 		},
 		"node_modules/multer": {
-			"version": "1.4.5-lts.2",
-			"resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-			"integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
-			"deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/multer/-/multer-2.0.0.tgz",
+			"integrity": "sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==",
 			"license": "MIT",
 			"dependencies": {
 				"append-field": "^1.0.0",
@@ -10404,7 +10406,7 @@
 				"xtend": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 10.16.0"
 			}
 		},
 		"node_modules/multer/node_modules/media-typer": {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,12 @@
 		"typescript": "^5.8.3",
 		"webpack": "^5.99.9"
 	},
+	"overrides": {
+		"multer": "2.0.0"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"jest": {
 		"moduleFileExtensions": [
 			"js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration to require Node.js version 22.0.0 or higher.
	- Ensured the app always uses version 2.0.0 of the multer package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->